### PR TITLE
support bug in ansible-2.0.0.2 that will be fixed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@ provision_docker_image_default: "chrismeyers/centos6"
 provision_docker_privileged: false
 provision_docker_ip: "127.0.0.1"
 provision_docker_company: 'ansible'
-provision_docker_dir: "{{ lookup('pipe','pwd')|dirname }}"
 provision_docker_ssh_user: "root"
 provision_docker_ssh_pass: "docker.io"
 provision_docker_use_tls: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,8 @@
 # docker_inspect.sh
 - name: Get IP of container
   local_action:
-    module: "shell cd {{ provision_docker_dir }} && ./files/docker_inspect.sh {{ item.name }}"
+    module: "shell"
+    args: "{{ role_path }}/files/docker_inspect.sh {{ item.name }}"
   register: provision_docker_ip
   with_items: provision_docker_inventory
 


### PR DESCRIPTION
- local_action + shell or command ignores args after module name on
  module: line
