### PR TITLE
Allow more configuration options, retrieve ip even with 'docker' connection type, fix ping not working without python

### DIFF
--- a/tasks/inc_cloud_iface.yml
+++ b/tasks/inc_cloud_iface.yml
@@ -5,7 +5,7 @@
     image: "{{ item.image|default(provision_docker_image_default) }}"
     privileged: "{{ provision_docker_privileged }}"
     state: "{{ provision_docker_state }}"
-    restart: yes
+    restart: "{{ item.restart|default(yes) }}"
     tls: "{{ provision_docker_use_tls }}"
     stop_timeout: 1
     tty: "{{provision_docker_use_docker_connection | bool}}"

--- a/tasks/inc_cloud_iface.yml
+++ b/tasks/inc_cloud_iface.yml
@@ -9,9 +9,19 @@
     tls: "{{ provision_docker_use_tls }}"
     stop_timeout: 1
     tty: "{{provision_docker_use_docker_connection | bool}}"
-    expose:
-      - "1-65535"
+    expose: "{{ item.expose|default(['1-65535']) }}"
+    command: "{{ item.command|default(omit) }}"
+    env: "{{ item.env|default(omit) }}"
+    links: "{{ item.inks|default(omit) }}"
   with_items: "{{ provision_docker_inventory }}"
+
+- name: Get IP of container
+  local_action:
+    module: "shell"
+    args: "{{ role_path }}/files/docker_inspect.sh {{ item.name }}"
+  register: provision_docker_ip
+  with_items: "{{ provision_docker_inventory }}"
+  changed_when: false
 
 - block:
   # Note: We had to move the invocation of the docker inspect command into a bash
@@ -22,13 +32,6 @@
   # exist
   # TODO: Check if no results (i.e. results.stdout_lines length) returned from
   # docker_inspect.sh
-  - name: Get IP of container
-    local_action:
-      module: "shell"
-      args: "{{ role_path }}/files/docker_inspect.sh {{ item.name }}"
-    register: provision_docker_ip
-    with_items: "{{ provision_docker_inventory }}"
-    changed_when: false
 
   # TODO: copy ALL host vars in the inventory
   - name: "Associate ip address with hosts"
@@ -56,6 +59,7 @@
   local_action:
     module: add_host
     name: "{{ item.1['name'] }}"
+    docker_ip: "{{ provision_docker_ip.results[item.0].stdout }}"
     ansible_connection: docker
     ansible_user: root
     groups: "{{ provision_docker_groups | union(item.1['groups']|default([])) | join(',') }}"
@@ -64,7 +68,6 @@
   when: provision_docker_use_docker_connection
 
 - name: Make sure able to connect to hosts
-  ping:
+  raw: echo Hello
   delegate_to: "{{ item['name'] }}"
   with_items: "{{ provision_docker_inventory }}"
-

--- a/tasks/inc_cloud_iface.yml
+++ b/tasks/inc_cloud_iface.yml
@@ -5,7 +5,7 @@
     image: "{{ item.image|default(provision_docker_image_default) }}"
     privileged: "{{ provision_docker_privileged }}"
     state: "{{ provision_docker_state }}"
-    restart: "{{ item.restart|default(yes) }}"
+    restart: "{{ item.restart|default(True) }}"
     tls: "{{ provision_docker_use_tls }}"
     stop_timeout: 1
     tty: "{{provision_docker_use_docker_connection | bool}}"

--- a/tasks/inc_inventory_iface.yml
+++ b/tasks/inc_inventory_iface.yml
@@ -6,7 +6,7 @@
     image: "{{ hostvars[item].image|default(provision_docker_image_default) }}"
     privileged: "{{ hostvars[item].privileged|default(provision_docker_privileged) | bool}}"
     state: "{{ hostvars[item].provision_docker_state | default(provision_docker_state) }}"
-    restart: "{{ item.restart|default(yes) }}"
+    restart: "{{ item.restart|default(True) }}"
     tls: "{{ provision_docker_use_tls }}"
     stop_timeout: 1
     tty: "{{provision_docker_use_docker_connection | bool}}"

--- a/tasks/inc_inventory_iface.yml
+++ b/tasks/inc_inventory_iface.yml
@@ -10,19 +10,23 @@
     tls: "{{ provision_docker_use_tls }}"
     stop_timeout: 1
     tty: "{{provision_docker_use_docker_connection | bool}}"
-    expose:
-      - "1-65535"
+    expose: "{{ item.expose|default(['1-65535']) }}"
+    command: "{{ item.command|default(omit) }}"
+    env: "{{ item.env|default(omit) }}"
+    links: "{{ item.inks|default(omit) }}"
   with_items: "{{ provision_docker_inventory_group }}"
 
-- block:
-    - name: Get IP of container
-      local_action:
-        module: "shell"
-        args: "{{ role_path }}/files/docker_inspect.sh {{ item }}"
-      register: provision_docker_ip
-      with_items: "{{ provision_docker_inventory_group }}"
-      changed_when: false
+- name: Get IP of container
+  local_action:
+    module: "shell"
+    args: "{{ role_path }}/files/docker_inspect.sh {{ item }}"
+  register: provision_docker_ip
+  with_items: "{{ provision_docker_inventory_group }}"
+  changed_when: false
 
+- debug: msg="{{provision_docker_ip}}"
+
+- block:
     - name: "Associate ip address with hosts"
       set_fact:
         ansible_ssh_host: "{{ provision_docker_ip.results[item.0].stdout }}"
@@ -54,6 +58,7 @@
       local_action:
         module: add_host
         name: "{{ item.1 }}"
+        docker_ip: "{{ provision_docker_ip.results[item.0].stdout }}"
         ansible_connection: docker
         ansible_user: root
         groups: "{{ provision_docker_groups | union(item.1['groups']|default([])) | join(',') }}"

--- a/tasks/inc_inventory_iface.yml
+++ b/tasks/inc_inventory_iface.yml
@@ -6,7 +6,7 @@
     image: "{{ hostvars[item].image|default(provision_docker_image_default) }}"
     privileged: "{{ hostvars[item].privileged|default(provision_docker_privileged) | bool}}"
     state: "{{ hostvars[item].provision_docker_state | default(provision_docker_state) }}"
-    restart: yes
+    restart: "{{ item.restart|default(yes) }}"
     tls: "{{ provision_docker_use_tls }}"
     stop_timeout: 1
     tty: "{{provision_docker_use_docker_connection | bool}}"


### PR DESCRIPTION
  - Allow more configuration options,
  - retrieve ip even with 'docker' connection type
  - fix connection check not working without python