### PR TITLE
Revert "Improve retrieving ip of container"

### DIFF
--- a/files/docker_inspect.sh
+++ b/files/docker_inspect.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker inspect --format='{{.NetworkSettings.IPAddress}}' $1

--- a/tasks/inc_cloud_iface.yml
+++ b/tasks/inc_cloud_iface.yml
@@ -17,13 +17,22 @@
 
 - name: Get IP of container
   local_action:
-    module: "command"
-    args: "docker inspect --format '{{ '{{' }} .NetworkSettings.IPAddress {{ '}}' }}' {{ item.name }}"
+    module: "shell"
+    args: "{{ role_path }}/files/docker_inspect.sh {{ item.name }}"
   register: provision_docker_ip
   with_items: "{{ provision_docker_inventory }}"
   changed_when: false
 
 - block:
+  # Note: We had to move the invocation of the docker inspect command into a bash
+  # script because it involces a command line parameter with {{ }}. Registering
+  # the results puts the command line params into invocation. Referencing the
+  # results variable fails because Ansible runs the invocation through jinja2
+  # template engine and the {{.NetworkSettings.IPAddress}} variable does not
+  # exist
+  # TODO: Check if no results (i.e. results.stdout_lines length) returned from
+  # docker_inspect.sh
+
   # TODO: copy ALL host vars in the inventory
   - name: "Associate ip address with hosts"
     local_action:

--- a/tasks/inc_inventory_iface.yml
+++ b/tasks/inc_inventory_iface.yml
@@ -18,11 +18,13 @@
 
 - name: Get IP of container
   local_action:
-    module: "command"
-    args: "docker inspect --format '{{ '{{' }} .NetworkSettings.IPAddress {{ '}}' }}' {{ item }}"
+    module: "shell"
+    args: "{{ role_path }}/files/docker_inspect.sh {{ item }}"
   register: provision_docker_ip
   with_items: "{{ provision_docker_inventory_group }}"
   changed_when: false
+
+- debug: msg="{{provision_docker_ip}}"
 
 - block:
     - name: "Associate ip address with hosts"


### PR DESCRIPTION
Reverts chrismeyersfsu/provision_docker#36

Due to a bug/change in Ansible 2.2.1.0 we need to go back to getting the ip address of the container through a shell script because of how Ansible handles jinja2 looking variables in registered variables (see below bug report).

Bug in `provision_docker` project filed #37
Ansible core bug filed https://github.com/ansible/ansible/issues/21782