### PR TITLE
Fix warnings regarding to when statements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,8 @@
   when: "provision_docker_inventory_group is not defined and provision_docker_inventory is not defined"
 
 - include: inc_inventory_iface.yml
-  when: "{{ provision_docker_inventory_group | length }} > 0"
+  when: (provision_docker_inventory_group | length) > 0
 
 - include: inc_cloud_iface.yml
-  when: "{{ provision_docker_inventory | length }} > 0"
+  when: (provision_docker_inventory | length) > 0
 


### PR DESCRIPTION
Since ansible 2.3 there are new warnings about wrong when statements.
This commit fixes them.

[WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ provision_docker_inventory_group | length }}
> 0