### PR TITLE
allow docker hosts to be remote for this role

### DIFF
--- a/tasks/inc_cloud_iface.yml
+++ b/tasks/inc_cloud_iface.yml
@@ -1,6 +1,5 @@
 - name: Bring up list of hosts
-  local_action:
-    module: docker_container
+  docker_container:
     name: "{{ item['name'] }}"
     image: "{{ item.image|default(provision_docker_image_default) }}"
     privileged: "{{ provision_docker_privileged }}"
@@ -17,9 +16,7 @@
   with_items: "{{ provision_docker_inventory }}"
 
 - name: Get IP of container
-  local_action:
-    module: "shell"
-    args: "{{ role_path }}/files/docker_inspect.sh {{ item.name }}"
+  shell: "{{ role_path }}/files/docker_inspect.sh {{ item.name }}"
   register: provision_docker_ip
   with_items: "{{ provision_docker_inventory }}"
   changed_when: false
@@ -36,8 +33,7 @@
 
   # TODO: copy ALL host vars in the inventory
   - name: "Associate ip address with hosts"
-    local_action:
-      module: add_host
+    add_host:
       name: "{{ item.1['name'] }}"
       ansible_ssh_host: "{{ provision_docker_ip.results[item.0].stdout }}"
       ansible_ssh_user: "{{ item.1['ansible_ssh_user']|default(provision_docker_ssh_user) }}"
@@ -57,8 +53,7 @@
 
 # TODO: copy ALL host vars in the inventory
 - name: "Add docker hosts with connection docker"
-  local_action:
-    module: add_host
+  add_host:
     name: "{{ item.1['name'] }}"
     docker_ip: "{{ provision_docker_ip.results[item.0].stdout }}"
     ansible_connection: docker

--- a/tasks/inc_inventory_iface.yml
+++ b/tasks/inc_inventory_iface.yml
@@ -1,6 +1,5 @@
 - name: Bring up inventory group of hosts
-  local_action:
-    module: docker_container
+  docker_container:
     # TODO: |default(random_hostname)
     name: "{{ item }}"
     image: "{{ hostvars[item].image|default(provision_docker_image_default) }}"
@@ -18,9 +17,7 @@
   with_items: "{{ provision_docker_inventory_group }}"
 
 - name: Get IP of container
-  local_action:
-    module: "shell"
-    args: "{{ role_path }}/files/docker_inspect.sh {{ item }}"
+  shell: "{{ role_path }}/files/docker_inspect.sh {{ item }}"
   register: provision_docker_ip
   with_items: "{{ provision_docker_inventory_group }}"
   changed_when: false
@@ -56,7 +53,7 @@
 - block:
     # TODO: copy ALL host vars in the inventory
     - name: "Add docker hosts with connection docker"
-      local_action:
+      add_host:
         module: add_host
         name: "{{ item.1 }}"
         docker_ip: "{{ provision_docker_ip.results[item.0].stdout }}"


### PR DESCRIPTION
### Use Case

Let's say you have two remote beefy servers. You want to use `provision_docker` to bring up 100 containers on each. The machine you are running Ansible on is your laptop. Previously, the `provision_docker` role would do `local_actions`. This is no longer the case. Instead, the user may control the set of hosts that the role `provision_docker` runs on. For example:

```
[docker_beef]
beefy1
beefy2
```

```
- hosts: docker_beef
  roles:
    - role: "provision_docker"
      ...
```

The above playbook will bring up docker containers on both `beefy1` and `beefy2`