### PR TITLE
Add libselinux-python package for RedHat systems

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,8 @@
   fail: msg="provision_docker_inventory_group or provision_docker_inventory is required"
   when: "provision_docker_inventory_group is not defined and provision_docker_inventory is not defined"
 
+- include: setup_requirements.yml
+
 - include: inc_inventory_iface.yml
   when: (provision_docker_inventory_group | length) > 0
 

--- a/tasks/setup_requirements.yml
+++ b/tasks/setup_requirements.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Gather facts
+  setup:
+
+- name: Install libselinux-python package for 'copy' task
+  yum:
+    name: libselinux-python
+    state: present
+  when: ansible_os_family == "RedHat"


### PR DESCRIPTION
It is required by copy module when system has selinux enabled
Fix: #49