### PR TITLE
Rpmdb checksum is invalid: dCDPT

### DIFF
--- a/files/Dockerfile.centos_6
+++ b/files/Dockerfile.centos_6
@@ -2,7 +2,7 @@ FROM centos:6
 ENV container docker
 
 # Update all base packages to keep them fresh
-RUN yum -y update; yum clean all
+RUN yum -y update; yum clean all; yum install -y yum-plugin-ovl
 
 # Install initscripts, but turn off all services by default
 RUN yum -y install initscripts; yum clean all; rm /etc/rc.d/rc*.d/*

--- a/files/Dockerfile.centos_7
+++ b/files/Dockerfile.centos_7
@@ -1,7 +1,7 @@
 FROM centos:centos7
 ENV container docker
 
-RUN yum -y update; yum clean all
+RUN yum -y update; yum clean all; yum install -y yum-plugin-ovl
 
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs dbus fsck.ext4
 


### PR DESCRIPTION
This fixes an issue that appears when trying to install packages with the CentOS 7 or CentOS 6 images.