### PR TITLE
init provision_docker module

### DIFF
--- a/action_plugins/provision_docker.py
+++ b/action_plugins/provision_docker.py
@@ -1,0 +1,46 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import requests
+import sys
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        self._supports_check_mode = False
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        params = dict()
+        _tmp_args = self._task.args.copy()
+
+        inventory_hostname = task_vars.get('inventory_hostname')
+        defaults = {
+            'name': inventory_hostname,
+            'image': 'chrismeyers/centos6',
+            'privileged': True,
+            'state': "started",
+            'restart': True,
+            'tls': True,
+            'stop_timeout': 1,
+            'tty': True,
+            'expose': "['1-65535']",
+        }
+        # TODO: Remove host_vars keys from task_vars
+        for k, v in defaults.iteritems():
+            _tmp_args.setdefault(k, v)
+
+        result.update(self._execute_module('docker_container', module_args=_tmp_args, task_vars=task_vars))
+
+        host_vars = {
+            'ansible_connection': 'docker',
+        }
+        result['add_host'] = dict(host_name=defaults['name'], groups=task_vars['group_names'], host_vars=host_vars)
+
+        result['changed'] = True
+        return result

--- a/library/provision_docker
+++ b/library/provision_docker
@@ -1,0 +1,40 @@
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'Chris Meyers'}
+
+
+DOCUMENTATION = '''
+---
+module: provision_docker
+short_description: Provision docker images for purposes of testing.
+description:
+  - Start docker containers for purposes of CI/CD.
+version_added: "2.3"
+options:
+  name:
+    description:
+    - Name of the docker image.
+    required: true
+  image:
+    description:
+    - Docker image to start (defaults to chrismeyers/centos6)
+    required: true
+  privileged:
+    description:
+    - Defaults to True. Start container in privileged mode or not.
+    required: false
+  state:
+    description:
+    - Defaults to 'started'. Can be 'stopped' to stop a container
+    required: false
+
+notes:
+    - Always 'changed'
+author:
+    - "Chris Meyers"
+'''
+
+EXAMPLES = '''
+- provision_docker:
+    name: "my_nginx_container"
+'''

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@
 
 containers = provision_docker_host_one provision_docker_host_two provision_docker_host_three provision_docker_host_four provision_docker_host_five optimus ironhide megatron starscream
 
-all: cloud inventory docker_inventory docker_cloud groups network_mode docker_links docker_volumes_inventory docker_volumes_cloud
+all: provision_docker cloud inventory docker_inventory docker_cloud groups network_mode docker_links docker_volumes_inventory docker_volumes_cloud
 
 cloud:
 	docker rm -f $(containers) || true
@@ -40,3 +40,6 @@ docker_volumes_cloud: clean
 
 clean:
 	docker rm -f $(containers) || true
+
+provision_docker: clean
+	ansible-playbook -i inventory playbooks/test_default.yml

--- a/test/ansible.cfg
+++ b/test/ansible.cfg
@@ -2,6 +2,8 @@
 host_key_checking = False
 retry_files_enabled = False
 ansible_python_interpreter = python
+action_plugins = ../action_plugins/
+library = ../library/
 
 [paramiko_connection]
 record_host_keys = False

--- a/test/playbooks/test_default.yml
+++ b/test/playbooks/test_default.yml
@@ -1,0 +1,11 @@
+- hosts: robots
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: "Invoke default docker provision"
+      provision_docker:
+
+- hosts: robots
+  gather_facts: true
+  tasks:
+    - shell: ls


### PR DESCRIPTION
Instead of implementing the functionality of `provision_docker` as a hacky role with a lot of output generated; instead, implement `provision_docker` as an action module in python. This is nice because we can forward a lot of the params to the underlying docker invocation instead of adding a translation parameter for each feature (i.e. ports, network, etc.)

related to #53

* Conforms to the inventory API (i.e. dummy hosts added to the
inventory).
* Supports docker connection plugin only (not yet ssh)
  
  
**Looking for feedback on this direction/implementation.**