### PR TITLE
Make role ansible 2.4 compatible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,11 @@
   fail: msg="provision_docker_inventory_group or provision_docker_inventory is required"
   when: "provision_docker_inventory_group is not defined and provision_docker_inventory is not defined"
 
-- include: setup_requirements.yml
+- import_tasks: setup_requirements.yml
 
-- include: inc_inventory_iface.yml
+- import_tasks: inc_inventory_iface.yml
   when: (provision_docker_inventory_group | length) > 0
 
-- include: inc_cloud_iface.yml
+- import_tasks: inc_cloud_iface.yml
   when: (provision_docker_inventory | length) > 0
 

--- a/test/playbook_cloud_iface.yml
+++ b/test/playbook_cloud_iface.yml
@@ -21,5 +21,5 @@
     # Role under test
     - { role: test_add_file, test_add_file_path: "{{ file }}"  }
   tasks:
-    - include: "inc_verify_hosts.yml"
+    - import_tasks: "inc_verify_hosts.yml"
 

--- a/test/playbook_cloud_iface_docker_connection.yml
+++ b/test/playbook_cloud_iface_docker_connection.yml
@@ -23,5 +23,5 @@
     # Role under test
     - { role: test_add_file, test_add_file_path: "{{ file }}"  }
   tasks:
-    - include: "inc_verify_hosts.yml"
+    - import_tasks: "inc_verify_hosts.yml"
 

--- a/test/playbook_inventory_iface.yml
+++ b/test/playbook_inventory_iface.yml
@@ -16,5 +16,5 @@
       test_add_file_path: "{{ file }}"
 
   tasks:
-    - include: inc_verify_transformers.yml
+    - import_tasks: inc_verify_transformers.yml
 

--- a/test/playbook_inventory_iface_docker_connection.yml
+++ b/test/playbook_inventory_iface_docker_connection.yml
@@ -18,4 +18,4 @@
       test_add_file_path: "{{ file }}"
 
   tasks:
-    - include: inc_verify_transformers.yml
+    - import_tasks: inc_verify_transformers.yml


### PR DESCRIPTION
Fixes
```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks'
for dynamic inclusions. This feature will be removed in a future release.
```