### PR TITLE
Bump minimum Ansible version to 2.4

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Provision docker containers using inventory.
   company: Ansible
   license: license (GPLv2, CC-BY, etc)
-  min_ansible_version: 2.0
+  min_ansible_version: 2.4
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 


### PR DESCRIPTION
#64 broke compatibility with Ansible < 2.4, updating role meta accordingly.