### PR TITLE
add the ability to skip the packages installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ provision_docker_inventory_group: []
 provision_docker_groups:
   - 'docker_containers'
 provision_docker_use_docker_connection: true
+provision_docker_install_packages: true

--- a/tasks/setup_requirements.yml
+++ b/tasks/setup_requirements.yml
@@ -7,4 +7,4 @@
   package:
     name: libselinux-python
     state: present
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and provision_docker_install_packages


### PR DESCRIPTION
The local installation of libselinux-python is the sole task requiring
root privilege. The `provision_docker_install_packages` parameter
allow anyone to skip it and continue to run the role with a regular
account.