### PR TITLE
Disabling unnecessary timer

### DIFF
--- a/files/Dockerfile.centos_7
+++ b/files/Dockerfile.centos_7
@@ -8,7 +8,7 @@ RUN yum -y swap -- remove systemd-container systemd-container-libs -- install sy
 RUN systemctl mask dev-mqueue.mount dev-hugepages.mount \
     systemd-remount-fs.service sys-kernel-config.mount \
     sys-kernel-debug.mount sys-fs-fuse-connections.mount \
-    display-manager.service graphical.target systemd-logind.service
+    display-manager.service graphical.target systemd-logind.service systemd-tmpfiles-clean.timer
 
 #RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
 #RUN yum -y update; yum clean all; \


### PR DESCRIPTION
Quick improvement - disabling an unnecessary timer that cleans the /tmp directory when the container starts